### PR TITLE
cargo: use 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aliasx"
-version = "0.1.3"
-edition = "2024"
+version = "0.1.4"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.100"


### PR DESCRIPTION
Some users have issues compiling with the latest featureset. Not using any of them so let's just add some compatibility.