### PR TITLE
executor: add custom executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,8 +27,8 @@ name = "aliasx-core"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "execute",
  "indexmap",
+ "nix 0.31.2",
  "owo-colors",
  "regex",
  "serde",
@@ -163,7 +163,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -310,7 +310,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "typenum",
 ]
 
@@ -467,43 +467,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "execute"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be3cc61fe54b4cae4463cdbda0401978ffe19d4dcc7a5201a312cddf64726dd"
-dependencies = [
- "execute-command-macro",
- "execute-command-tokens",
- "generic-array 1.3.5",
-]
-
-[[package]]
-name = "execute-command-macro"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e748391d89b43c52decaed8645b4a83a09d14f5ee868071c6813389e9e7036"
-dependencies = [
- "execute-command-macro-impl",
-]
-
-[[package]]
-name = "execute-command-macro-impl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57dd896da3fbb77138059b015c013459d96063c66bcdd3b9094ff2e9d3f19a47"
-dependencies = [
- "execute-command-tokens",
- "quote",
- "syn 2.0.112",
-]
-
-[[package]]
-name = "execute-command-tokens"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729eda2ea2f6c5ef85150c85a9b2ce0a8e01f040e59cdb32521eaa6c840c9d51"
-
-[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,16 +525,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "generic-array"
-version = "1.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
-dependencies = [
- "rustversion",
- "typenum",
 ]
 
 [[package]]
@@ -773,9 +726,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libredox"
@@ -838,7 +791,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -892,6 +845,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1578,7 +1543,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "aliasx-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aliasx-core",
  "aliasx-tui",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "aliasx-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "aliasx-tui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aliasx-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 

--- a/aliasx-core/Cargo.toml
+++ b/aliasx-core/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 
 [dependencies]
 anyhow = "1.0.100"
-execute = "0.2.13"
 indexmap = { version="2.12.1", features = ["serde"] }
+nix = { version = "0.31.2", features = ["signal", "process", "term", "fs", "poll"] }
 owo-colors = { version = "4.2.3", features = ["supports-colors"] }
 regex = "1.12.2"
 serde = { version="1.0.228", features = ["derive"] }

--- a/aliasx-core/src/aliases.rs
+++ b/aliasx-core/src/aliases.rs
@@ -1,6 +1,5 @@
-use anyhow::Result;
-use execute::Execute;
-use std::process::{Command, Stdio};
+use anyhow::{Context, Result};
+use std::process::Stdio;
 
 use crate::task_collection::TaskCollection;
 use crate::tasks::{TaskEntry, Tasks};
@@ -27,11 +26,11 @@ fn parse_aliases(output: &str) -> Result<Tasks> {
 pub fn get_aliases_as_tasks() -> anyhow::Result<TaskCollection> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".into());
 
-    let mut command = Command::new(shell);
-    command.args(["-ic", "alias"]);
-    command.stdout(Stdio::piped());
-
-    let output = command.execute_output()?;
+    let output = std::process::Command::new(shell)
+        .args(["-ic", "alias"])
+        .stdout(Stdio::piped())
+        .output()
+        .context("failed to execute alias command")?;
 
     match output.status.code() {
         Some(0) => {}

--- a/aliasx-core/src/executor.rs
+++ b/aliasx-core/src/executor.rs
@@ -1,0 +1,176 @@
+use anyhow::Context;
+use nix::sys::select::{select, FdSet};
+use nix::sys::signal::*;
+use nix::sys::signalfd::{SfdFlags, SignalFd};
+use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+use nix::unistd::{setpgid, Pid};
+use std::io::IsTerminal;
+use std::os::fd::{AsFd, AsRawFd};
+use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::process::{Command, ExitStatus, Stdio};
+
+pub struct Executor {
+    command: String,
+}
+
+impl Executor {
+    pub fn new(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+        }
+    }
+
+    pub fn run(self) -> anyhow::Result<ExitStatus> {
+        // Block SIGTSTP in parent so we can handle it via signalfd.
+        // The child will unblock it in pre_exec so it suspends normally.
+        let mut tstp_mask = SigSet::empty();
+        tstp_mask.add(Signal::SIGTSTP);
+        sigprocmask(SigmaskHow::SIG_BLOCK, Some(&tstp_mask), None)?;
+
+        let sfd = SignalFd::with_flags(&tstp_mask, SfdFlags::SFD_CLOEXEC)?;
+
+        let child = self.spawn(&tstp_mask)?;
+        let child_pid = Pid::from_raw(child as i32);
+        let child_pgid = child_pid;
+
+        let stdin = std::io::stdin();
+        let is_tty = stdin.is_terminal();
+        let our_pgid = nix::unistd::getpgrp();
+
+        ignore_signals()?;
+
+        if is_tty {
+            handoff_tty(stdin.as_fd(), child_pgid)
+                .context("failed to hand TTY control to child")?;
+        }
+
+        let exit_status = self.event_loop(child_pid, child_pgid, our_pgid, &stdin, &sfd, is_tty)?;
+
+        if is_tty {
+            reclaim_tty(stdin.as_fd(), our_pgid).context("failed to reclaim TTY control")?;
+        }
+
+        restore_signals()?;
+        sigprocmask(SigmaskHow::SIG_UNBLOCK, Some(&tstp_mask), None)?;
+
+        Ok(exit_status)
+    }
+
+    fn spawn(&self, tstp_mask: &SigSet) -> anyhow::Result<u32> {
+        let tstp_mask = *tstp_mask;
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", &self.command])
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+
+        unsafe {
+            cmd.pre_exec(move || {
+                // Own process group — Ctrl+C goes to child directly, not parent
+                setpgid(Pid::from_raw(0), Pid::from_raw(0))
+                    .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                // Unblock SIGTSTP so child can be suspended normally
+                sigprocmask(SigmaskHow::SIG_UNBLOCK, Some(&tstp_mask), None)
+                    .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                Ok(())
+            });
+        }
+
+        let child = cmd.spawn().context("failed to spawn command")?;
+        Ok(child.id())
+    }
+
+    fn event_loop(
+        &self,
+        child_pid: Pid,
+        child_pgid: Pid,
+        our_pgid: Pid,
+        stdin: &std::io::Stdin,
+        sfd: &SignalFd,
+        is_tty: bool,
+    ) -> anyhow::Result<ExitStatus> {
+        let mut tstp_mask = SigSet::empty();
+        tstp_mask.add(Signal::SIGTSTP);
+
+        loop {
+            // Check child state without blocking
+            match waitpid(
+                child_pid,
+                Some(WaitPidFlag::WNOHANG | WaitPidFlag::WUNTRACED),
+            )? {
+                WaitStatus::Exited(_, code) => {
+                    return Ok(ExitStatus::from_raw(code << 8));
+                }
+                WaitStatus::Signaled(_, sig, _) => {
+                    return Ok(ExitStatus::from_raw(sig as i32));
+                }
+                WaitStatus::Stopped(_, _) => {
+                    // Child was stopped via Ctrl+Z — suspend ourselves too
+                    if is_tty {
+                        reclaim_tty(stdin.as_fd(), our_pgid).ok();
+                    }
+                    restore_signals()?;
+                    sigprocmask(SigmaskHow::SIG_UNBLOCK, Some(&tstp_mask), None)?;
+
+                    // Suspend — shell takes over here until `fg`
+                    nix::sys::signal::raise(Signal::SIGSTOP)?;
+
+                    // Resumed via fg
+                    sigprocmask(SigmaskHow::SIG_BLOCK, Some(&tstp_mask), None)?;
+                    ignore_signals()?;
+                    kill(child_pgid, Signal::SIGCONT)?;
+                    if is_tty {
+                        handoff_tty(stdin.as_fd(), child_pgid).ok();
+                    }
+                }
+                _ => {
+                    // Child still running — wait for SIGTSTP on signalfd
+                    let sfd_fd = sfd.as_fd();
+                    let mut fds = FdSet::new();
+                    fds.insert(sfd_fd);
+                    let mut tv = nix::sys::time::TimeVal::new(0, 50_000);
+                    if select(
+                        sfd_fd.as_raw_fd() + 1,
+                        Some(&mut fds),
+                        None,
+                        None,
+                        Some(&mut tv),
+                    )? > 0
+                    {
+                        sfd.read_signal().ok();
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn ignore_signals() -> anyhow::Result<()> {
+    let ign = SigAction::new(SigHandler::SigIgn, SaFlags::empty(), SigSet::empty());
+    unsafe {
+        sigaction(Signal::SIGINT, &ign)?;
+        sigaction(Signal::SIGTTOU, &ign)?;
+        sigaction(Signal::SIGTTIN, &ign)?;
+    }
+    Ok(())
+}
+
+fn restore_signals() -> anyhow::Result<()> {
+    let dfl = SigAction::new(SigHandler::SigDfl, SaFlags::empty(), SigSet::empty());
+    unsafe {
+        sigaction(Signal::SIGINT, &dfl)?;
+        sigaction(Signal::SIGTTOU, &dfl)?;
+        sigaction(Signal::SIGTTIN, &dfl)?;
+    }
+    Ok(())
+}
+
+fn handoff_tty(fd: std::os::fd::BorrowedFd<'_>, pgid: Pid) -> anyhow::Result<()> {
+    nix::unistd::tcsetpgrp(fd, pgid)?;
+    Ok(())
+}
+
+fn reclaim_tty(fd: std::os::fd::BorrowedFd<'_>, pgid: Pid) -> anyhow::Result<()> {
+    nix::unistd::tcsetpgrp(fd, pgid)?;
+    Ok(())
+}

--- a/aliasx-core/src/lib.rs
+++ b/aliasx-core/src/lib.rs
@@ -5,3 +5,4 @@ pub mod task_collection;
 pub mod tasks;
 pub mod validator;
 pub mod task_filter;
+pub mod executor;

--- a/aliasx-core/src/task_collection.rs
+++ b/aliasx-core/src/task_collection.rs
@@ -1,14 +1,12 @@
-use anyhow::{anyhow, Context};
-use execute::shell;
+use anyhow::anyhow;
 use indexmap::{IndexMap, IndexSet};
-use std::process::Stdio;
-
+use crate::executor::Executor;
+use crate::task_filter::TaskFilter;
 use crate::{
     input::Input,
     tasks::{TaskEntry, Tasks},
     validator::Validator,
 };
-use crate::task_filter::TaskFilter;
 
 #[derive(Debug, Default)]
 pub struct TaskCollection {
@@ -135,7 +133,12 @@ impl TaskCollection {
     }
 
     /// Execute task `id` with pre-collected `input_selections`.
-    pub fn execute(&self, id: usize, input_selections: IndexMap<String, String>, verbose: bool) -> anyhow::Result<()> {
+    pub fn execute(
+        &self,
+        id: usize,
+        input_selections: IndexMap<String, String>,
+        verbose: bool,
+    ) -> anyhow::Result<()> {
         let (task_set, task) = self.find_task(id)?;
 
         let mut task_command = task.command.clone();
@@ -160,21 +163,15 @@ impl TaskCollection {
     ) -> anyhow::Result<()> {
         println!("aliasx | {}\n", task.format(verbose));
 
-        let mut cmd = shell(&task_command);
-        cmd.stdin(Stdio::inherit())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit());
-
-        let status = cmd.status().with_context(|| "failed to execute command")?;
+        let status = Executor::new(task_command).run()?;
 
         if !status.success() {
-            let code_str = status
+            let code = status
                 .code()
                 .map_or_else(|| "unknown".to_string(), |c| c.to_string());
-
             return Err(anyhow!(
                 "command exited with non-zero status (err={})",
-                code_str
+                code
             ));
         }
 


### PR DESCRIPTION
This executor has a few benefits over what we previously used:

SIGINT is now forwarded to the process itself instead of to aliasx. This
is rather useful for tools that handles signals itself (eg. gdb).

We can now remove the executor package and all its dependencies.

One note is that it's now only unix support. Which is fine for now.

Signed-off-by: Hans Binderup <hbinderup94@gmail.com>