### PR TITLE
tasks: add conditions

### DIFF
--- a/.aliasx.yaml
+++ b/.aliasx.yaml
@@ -27,6 +27,7 @@ tasks:
         - "something-invalid"
       files:
         - "FILE_THAT_DOES_NOT_EXIST"
+        - "[invalidglob"
   - label: "Git status"
     command: "git status"
     description: "Get git status when .git dir exists or when in any 'repos/github' sub-folder"

--- a/.aliasx.yaml
+++ b/.aliasx.yaml
@@ -20,6 +20,23 @@ tasks:
     command: "echo 'error: input: ${input:some-invalid-input}'"
   - label: "Task with partial mapping"
     command: "echo 'error: input: ${mapping:misser}'"
+  - label: "Should not be shown!"
+    command: "echo  'conditions should not be true!'"
+    conditions:
+      paths:
+        - "something-invalid"
+      files:
+        - "FILE_THAT_DOES_NOT_EXIST"
+  - label: "Git status"
+    command: "git status"
+    description: "Get git status when .git dir exists or when in any 'repos/github' sub-folder"
+    conditions:
+      files:
+        - ".git"
+      paths:
+        - "**/repos/**"
+        - "/home/user/github/**"
+
 inputs:
   - id: some-int
     description: "just an int"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "execute",
+ "globset",
  "indexmap",
  "owo-colors",
  "regex",
@@ -164,6 +165,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -608,6 +619,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ For full feature set see the [documentation](docs/README.md)
 - Support variable inputs
     - instead of fixed input types also support manually inputting a variable
 - Convert vscode.json file to aliasx.yaml syntax
-- Conditionals - only enable tasks given some constraints
 - Depends on - trigger other tasks before running this one
 - Create base config - prompt aliasx to create some "boiler plate configs"
 

--- a/aliasx-cli/src/cli.rs
+++ b/aliasx-cli/src/cli.rs
@@ -4,7 +4,9 @@ use clap::{Parser, Subcommand};
 use indexmap::IndexMap;
 
 use aliasx_core::{
-    aliases, task_filter::TaskFilter, tasks::{self, TaskEntry}
+    aliases,
+    task_filter::TaskFilter,
+    tasks::{self, TaskEntry},
 };
 use aliasx_tui::{string_fuzzy_finder, string_fuzzy_finder_with, task_fuzzy_finder, TuiSession};
 
@@ -44,6 +46,10 @@ struct Cli {
     /// filter which tasks to include
     #[arg(short, long, value_parser = TaskFilter::from_str, default_value_t = TaskFilter::All)]
     filter: TaskFilter,
+
+    /// enable conditions
+    #[arg(short, long)]
+    conditions: Option<bool>,
 }
 
 #[derive(Subcommand)]
@@ -68,7 +74,10 @@ enum Commands {
 pub fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let index = &cli.index;
-    let enable_conditions = !matches!(cli.command, Some(Commands::Validate));
+
+    // default to enable conditions - but always disable when validating
+    let enable_conditions =
+        cli.conditions.unwrap_or(true) && !matches!(cli.command, Some(Commands::Validate));
 
     let tasks = if cli.native {
         aliases::get_aliases_as_tasks()?
@@ -110,7 +119,12 @@ pub fn run() -> anyhow::Result<()> {
                     "input | {}:",
                     input.description.as_deref().unwrap_or(&input.id)
                 );
-                let (_, val) = string_fuzzy_finder(&input.options, &prompt, "", input.get_default_selection())?;
+                let (_, val) = string_fuzzy_finder(
+                    &input.options,
+                    &prompt,
+                    "",
+                    input.get_default_selection(),
+                )?;
                 selections.insert(input.id.clone(), val);
             }
             tasks.execute(idx, selections, cli.verbose)?;
@@ -120,9 +134,16 @@ pub fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_fzf(tasks: &aliasx_core::task_collection::TaskCollection, query: &str, verbose: bool) -> anyhow::Result<()> {
+fn run_fzf(
+    tasks: &aliasx_core::task_collection::TaskCollection,
+    query: &str,
+    verbose: bool,
+) -> anyhow::Result<()> {
     let indexed = tasks.indexed_tasks();
-    let entries: Vec<(usize, TaskFilter, &TaskEntry)> = indexed.iter().map(|(id, scope, t)| (*id, *scope, *t)).collect();
+    let entries: Vec<(usize, TaskFilter, &TaskEntry)> = indexed
+        .iter()
+        .map(|(id, scope, t)| (*id, *scope, *t))
+        .collect();
 
     let mut session = TuiSession::new()?;
     let selected_id = task_fuzzy_finder(&entries, &tasks, &mut session, query, verbose)?;
@@ -135,7 +156,13 @@ fn run_fzf(tasks: &aliasx_core::task_collection::TaskCollection, query: &str, ve
             "input | {}:",
             input.description.as_deref().unwrap_or(&input.id)
         );
-        let (_, val) = string_fuzzy_finder_with(&input.options, &prompt, "", input.get_default_selection(), &mut session)?;
+        let (_, val) = string_fuzzy_finder_with(
+            &input.options,
+            &prompt,
+            "",
+            input.get_default_selection(),
+            &mut session,
+        )?;
         selections.insert(input.id.clone(), val);
     }
 

--- a/aliasx-cli/src/cli.rs
+++ b/aliasx-cli/src/cli.rs
@@ -68,11 +68,12 @@ enum Commands {
 pub fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let index = &cli.index;
+    let enable_conditions = !matches!(cli.command, Some(Commands::Validate));
 
     let tasks = if cli.native {
         aliases::get_aliases_as_tasks()?
     } else {
-        tasks::get_all_tasks(cli.filter)?
+        tasks::get_all_tasks(cli.filter, enable_conditions)?
     };
 
     match &cli.command {

--- a/aliasx-core/Cargo.toml
+++ b/aliasx-core/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 anyhow = "1.0.100"
 execute = "0.2.13"
+globset = "0.4.18"
 indexmap = { version="2.12.1", features = ["serde"] }
 owo-colors = { version = "4.2.3", features = ["supports-colors"] }
 regex = "1.12.2"

--- a/aliasx-core/src/aliases.rs
+++ b/aliasx-core/src/aliases.rs
@@ -15,6 +15,7 @@ fn parse_aliases(output: &str) -> Result<Tasks> {
                 let task = TaskEntry {
                     label: name.trim().to_string(),
                     command: cmd.trim_matches('\'').to_string(),
+                    conditions: Option::None,
                 };
                 tasks.tasks.insert(task);
             }

--- a/aliasx-core/src/lib.rs
+++ b/aliasx-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod aliases;
 pub mod input;
 pub mod input_mapping;
 pub mod task_collection;
+pub mod task_conditions;
+pub mod task_filter;
 pub mod tasks;
 pub mod validator;
-pub mod task_filter;

--- a/aliasx-core/src/task_collection.rs
+++ b/aliasx-core/src/task_collection.rs
@@ -190,6 +190,7 @@ mod tests {
         TaskEntry {
             label: label.to_string(),
             command: command.to_string(),
+            conditions: Option::None,
         }
     }
 

--- a/aliasx-core/src/task_conditions.rs
+++ b/aliasx-core/src/task_conditions.rs
@@ -1,0 +1,183 @@
+use globset::{Glob, GlobSetBuilder};
+use serde::{Deserialize, Serialize};
+use std::{env, fs};
+
+#[derive(Hash, Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct TaskCondition {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
+}
+
+impl TaskCondition {
+    pub fn is_valid(&self) -> bool {
+        let cwd = match env::current_dir() {
+            Ok(p) => p,
+            Err(_) => return false, // default to false if we cannot determine the current directory
+        };
+
+        // Attempt to read entries from the real filesystem; pass them to is_valid_in.
+        let entries = fs::read_dir(&cwd).ok().map(|iter| {
+            iter.filter_map(|e| e.ok().and_then(|en| en.file_name().into_string().ok()))
+                .collect::<Vec<String>>()
+        });
+
+        self.is_valid_in(&cwd, entries.as_deref())
+    }
+
+    // This helper allows for testing the globs without the need for FS access
+    fn is_valid_in<P: AsRef<std::path::Path>>(&self, cwd: P, entries: Option<&[String]>) -> bool {
+        let cwd = cwd.as_ref();
+
+        if !self.paths.is_empty() {
+            let mut builder = GlobSetBuilder::new();
+
+            for pattern in &self.paths {
+                if let Ok(glob) = Glob::new(pattern) {
+                    builder.add(glob);
+                }
+            }
+
+            if let Ok(set) = builder.build() {
+                if set.is_match(cwd) {
+                    return true;
+                }
+            }
+        }
+
+        if !self.files.is_empty() {
+            let mut builder = GlobSetBuilder::new();
+
+            for pattern in &self.files {
+                if let Ok(glob) = Glob::new(pattern) {
+                    builder.add(glob);
+                }
+            }
+
+            if let Ok(set) = builder.build() {
+                if let Some(list) = entries {
+                    for name in list {
+                        if set.is_match(std::path::Path::new(name)) {
+                            return true;
+                        }
+                    }
+                } else if let Ok(dir_entries) = fs::read_dir(cwd) {
+                    for entry in dir_entries.flatten() {
+                        if set.is_match(entry.file_name()) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TaskCondition;
+    use std::path::PathBuf;
+
+    #[test]
+    fn empty_conditions_are_invalid() {
+        let c = TaskCondition {
+            paths: vec![],
+            files: vec![],
+        };
+        // Provide a fake cwd and an empty entry list; no fs used.
+        assert!(!c.is_valid_in(PathBuf::from("/some/cwd"), Some(&[])));
+    }
+
+    #[test]
+    fn matching_path_is_valid() {
+        let cwd = PathBuf::from("/home/user/project");
+        let pattern = cwd.to_str().unwrap().to_string();
+        let c = TaskCondition {
+            paths: vec![pattern],
+            files: vec![],
+        };
+        assert!(c.is_valid_in(&cwd, Some(&[])));
+    }
+
+    #[test]
+    fn matching_file_is_valid() {
+        let cwd = PathBuf::from("/home/user/project");
+        let fname = "marker.file".to_string();
+        let c = TaskCondition {
+            paths: vec![],
+            files: vec![fname.clone()],
+        };
+        // Provide entries containing the marker file; no disk IO.
+        assert!(c.is_valid_in(&cwd, Some(&[fname])));
+    }
+
+    #[test]
+    fn matching_dir_is_valid() {
+        let cwd = PathBuf::from("/home/user/project");
+        // Simulate a direct directory entry as returned by read_dir(cwd).
+        let fname = "some_dir".to_string();
+        let c = TaskCondition {
+            paths: vec![],
+            files: vec![fname.clone()],
+        };
+        // Provide entries containing the marker directory; no disk IO.
+        assert!(c.is_valid_in(&cwd, Some(&[fname])));
+    }
+
+    #[test]
+    fn mix_matches_by_path() {
+        let cwd = PathBuf::from("/home/user/project/foo");
+        let c = TaskCondition {
+            paths: vec!["/home/user/project/*".to_string()],
+            files: vec!["no-such-file".to_string()],
+        };
+        assert!(c.is_valid_in(&cwd, Some(&[])));
+    }
+
+    #[test]
+    fn mix_matches_by_file_glob() {
+        let cwd = PathBuf::from("/home/user/project");
+        let entries = vec!["app.log".to_string(), "README.md".to_string()];
+        let c = TaskCondition {
+            paths: vec!["/no/such/path".to_string()],
+            files: vec!["*.log".to_string()],
+        };
+        assert!(c.is_valid_in(&cwd, Some(&entries)));
+    }
+
+    #[test]
+    fn recursive_path_glob_matches() {
+        let cwd = PathBuf::from("/home/user/a/b/foo");
+        let c = TaskCondition {
+            paths: vec!["/home/user/**/foo".to_string()],
+            files: vec![],
+        };
+        assert!(c.is_valid_in(&cwd, Some(&[])));
+    }
+
+    #[test]
+    fn file_glob_question_mark_matches() {
+        let cwd = PathBuf::from("/project");
+        let entries = vec!["file1.txt".to_string(), "file2.txt".to_string()];
+        let c = TaskCondition {
+            paths: vec![],
+            files: vec!["file?.txt".to_string()],
+        };
+        assert!(c.is_valid_in(&cwd, Some(&entries)));
+    }
+
+    #[test]
+    fn negative_with_globs_is_invalid() {
+        let cwd = PathBuf::from("/no/match/here");
+        let entries = vec!["other.txt".to_string()];
+        let c = TaskCondition {
+            paths: vec!["/not/**/matching".to_string()],
+            files: vec!["*.log".to_string()],
+        };
+        assert!(!c.is_valid_in(&cwd, Some(&entries)));
+    }
+}

--- a/aliasx-core/src/task_conditions.rs
+++ b/aliasx-core/src/task_conditions.rs
@@ -75,6 +75,23 @@ impl TaskCondition {
 
         false
     }
+
+    // for simplicity - just return the first error if any
+    pub fn validate(&self) -> Option<String> {
+        for file in self.files.iter() {
+            if let Err(_) = Glob::new(file) {
+                return Some(format!("files: {}", file.clone()));
+            }
+        }
+
+        for path in self.paths.iter() {
+            if let Err(_) = Glob::new(path) {
+                return Some(format!("paths: {}", path.clone()));
+            }
+        }
+
+        Option::None
+    }
 }
 
 #[cfg(test)]

--- a/aliasx-core/src/tasks.rs
+++ b/aliasx-core/src/tasks.rs
@@ -6,12 +6,14 @@ use std::path::Path;
 use crate::input::Input;
 use crate::input_mapping::InputMapping;
 use crate::task_collection::TaskCollection;
+use crate::task_conditions::TaskCondition;
 use crate::task_filter::TaskFilter;
 
 #[derive(Hash, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct TaskEntry {
     pub label: String,
     pub command: String,
+    pub conditions: Option<TaskCondition>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -44,6 +46,16 @@ impl TaskEntry {
 }
 
 impl Tasks {
+    pub fn apply_conditions(&mut self) {
+        self.tasks.retain(|t| {
+            if let Some(c) = &t.conditions {
+                c.is_valid()
+            } else {
+                true
+            }
+        });
+    }
+
     pub fn get_input(&self, id: &str) -> anyhow::Result<&Input> {
         if self.inputs.is_empty() {
             return Err(anyhow!("no inputs defined"));
@@ -137,8 +149,7 @@ impl TaskReader for JsonTaskReader {
     }
 }
 
-
-pub fn get_all_tasks(filter: TaskFilter) -> anyhow::Result<TaskCollection> {
+pub fn get_all_tasks(filter: TaskFilter, apply_conditions: bool) -> anyhow::Result<TaskCollection> {
     let local_aliasx_path = Path::new(".aliasx.yaml");
     let local_vscode_tasks = Path::new(".vscode/tasks.json");
 
@@ -161,6 +172,12 @@ pub fn get_all_tasks(filter: TaskFilter) -> anyhow::Result<TaskCollection> {
         sources.push(global);
     }
 
+    if apply_conditions {
+        for source in sources.iter_mut() {
+            source.apply_conditions();
+        }
+    }
+
     Ok(TaskCollection::new(sources))
 }
 
@@ -172,6 +189,7 @@ mod tests {
         TaskEntry {
             label: label.to_string(),
             command: command.to_string(),
+            conditions: Option::None,
         }
     }
 

--- a/aliasx-core/src/validator.rs
+++ b/aliasx-core/src/validator.rs
@@ -136,6 +136,7 @@ impl Validator {
 
         report.add_statuses(self.check_inputs(entry, source));
         report.add_statuses(self.check_mappings(entry, source));
+        report.add_statuses(self.check_conditions(entry));
 
         report
     }
@@ -216,6 +217,18 @@ impl Validator {
                     mapping.id, mapping.input
                 ))]
             }
+        }
+    }
+
+    fn check_conditions(&self, entry: &TaskEntry) -> Option<ValidationStatus> {
+        if let Some(condition) = &entry.conditions {
+            if condition.is_valid() {
+                Some(ValidationStatus::pass("Conditions are met"))
+            } else {
+                Some(ValidationStatus::pass("Skipped as conditions are not met"))
+            }
+        } else {
+            Option::None
         }
     }
 

--- a/aliasx-core/src/validator.rs
+++ b/aliasx-core/src/validator.rs
@@ -9,6 +9,7 @@ use owo_colors::OwoColorize;
 pub enum ValidationStatus {
     Pass { message: String },
     Fail { message: String },
+    Skip { message: String },
 }
 
 impl ValidationStatus {
@@ -24,6 +25,12 @@ impl ValidationStatus {
         }
     }
 
+    fn skip(message: impl Into<String>) -> Self {
+        Self::Skip {
+            message: message.into(),
+        }
+    }
+
     pub fn is_pass(&self) -> bool {
         matches!(self, Self::Pass { .. })
     }
@@ -32,10 +39,17 @@ impl ValidationStatus {
         matches!(self, Self::Fail { .. })
     }
 
+    pub fn is_skip(&self) -> bool {
+        matches!(self, Self::Skip { .. })
+    }
+
     pub fn format(&self) -> String {
         match self {
             Self::Pass { message } => format!("{} {}", "✓".green().bold(), message.dimmed()),
             Self::Fail { message } => format!("{} {}", "✗".red().bold(), message),
+            Self::Skip { message } => {
+                format!("{} {} (skipped)", "⏭".yellow().bold(), message.dimmed())
+            }
         }
     }
 }
@@ -69,12 +83,20 @@ impl ValidationReport {
         self.statuses.iter().filter(|s| s.is_pass())
     }
 
+    pub fn skips(&self) -> impl Iterator<Item = &ValidationStatus> {
+        self.statuses.iter().filter(|s| s.is_skip())
+    }
+
     pub fn failure_count(&self) -> usize {
         self.failures().count()
     }
 
     pub fn pass_count(&self) -> usize {
         self.passes().count()
+    }
+
+    pub fn skip_count(&self) -> usize {
+        self.skips().count()
     }
 
     pub fn print(&self, verbose: bool) {
@@ -97,9 +119,13 @@ impl ValidationReport {
             println!("{}{}", self.validation_id.bold(), badge);
 
             // Print details with indentation
-            if verbose || fail_count > 0 {
+            if verbose {
                 for status in &self.statuses {
-                    if verbose || status.is_fail() {
+                    println!("  {}", status.format());
+                }
+            } else if fail_count > 0 {
+                for status in &self.statuses {
+                    if status.is_fail() {
                         println!("  {}", status.format());
                     }
                 }
@@ -222,10 +248,14 @@ impl Validator {
 
     fn check_conditions(&self, entry: &TaskEntry) -> Option<ValidationStatus> {
         if let Some(condition) = &entry.conditions {
+            if let Some(err) = condition.validate() {
+                return Some(ValidationStatus::fail(format!("Condition: '{}' is not valid", err)));
+            }
+
             if condition.is_valid() {
                 Some(ValidationStatus::pass("Conditions are met"))
             } else {
-                Some(ValidationStatus::pass("Skipped as conditions are not met"))
+                Some(ValidationStatus::skip("Conditions are not met"))
             }
         } else {
             Option::None

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,4 @@ This is the user-facing documentation index. Use it as a lookup to jump to focus
 6. [CLI](features/06-cli.md) - use aliasx without the TUI with direct cli commands
 7. [TUI](features/07-tui.md) - use aliasx with the tui for fuzzy finding and task selections (default)
 8. [Validation](features/08-validation.md) - let aliasx validate your configs for you!
-
----
-
-Navigation: ← [Installation](features/08-validation.md) | [Next: Installation & Getting Started](features/01-installation.md) →
+9. [Conditions](features/09-conditions.md) - enable/disable tasks based on provided conditions

--- a/docs/features/01-installation.md
+++ b/docs/features/01-installation.md
@@ -16,4 +16,4 @@
 
 ---
 
-Navigation: ← [Previous: Validation](08-validation.md) | [Next: Basics](02-basic.md) →
+Navigation: ← [Previous: Conditions](09-conditions.md) | [Next: Basics](02-basic.md) →

--- a/docs/features/06-cli.md
+++ b/docs/features/06-cli.md
@@ -37,8 +37,13 @@ Options:
 
   -f, --filter <FILTER>
           filter which tasks to include
-          
+
           [default: all]
+
+  -c, --conditions <CONDITIONS>
+          enable conditions
+
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -59,6 +64,7 @@ Quick start
 - `-n, --native`  : show only native shell aliases
 - `-f, --filter <local|global|all>` : restrict scope
 - `-v, --verbose` : verbose output
+- `-c, --conditions <true|false>` : enable or disable conditions (default: true; for example, use `--conditions false` to disable)
 
 ### fzf command flags:
 - `-q, --query <text>` : initial search query for the `fzf` / `f` subcommand (use as `aliasx fzf --query <text>` or `aliasx f --query <text>`)

--- a/docs/features/08-validation.md
+++ b/docs/features/08-validation.md
@@ -115,4 +115,4 @@ Cargo build package FAIL 1/3
 
 ---
 
-Navigation: ← [Previous: TUI](07-tui.md) | [Next: Installation & Getting Started](01-installation.md) →
+Navigation: ← [Previous: TUI](07-tui.md) | [Next: Conditions](09-conditions.md) →

--- a/docs/features/09-conditions.md
+++ b/docs/features/09-conditions.md
@@ -1,0 +1,78 @@
+# Configuration - Conditions
+
+`conditions` is an optional parameter to each task.
+`conditions` allows you to enable/disable tasks based on given criteria:
+
+- `paths` (optional) : if you're currently in a path matching any of the provided paths.
+- `files` (optional) : if any of the given files are matched with files in the current directory.
+
+## Examples
+
+```yaml
+version: "1.0.0"
+tasks:
+  - label: "Git status"
+    command: "git status"
+    description: "Get git status when .git dir exists or when in any 'repos/github' sub-folder"
+    conditions:
+      files:
+        - ".git"
+      paths:
+        - "**/repos/**"
+        - "/home/user/github/**"
+
+  - label: "Cargo build"
+    command: "cargo build"
+    description: "Build when Cargo.toml file is present"
+    conditions:
+      files:
+        - "Cargo.toml"
+
+  - label: "Should not be shown!"
+    command: "echo  'conditions should not be true!'"
+    conditions:
+      paths:
+        - "something-invalid"
+      files:
+        - "FILE_THAT_DOES_NOT_EXIST"
+```
+
+Key points
+
+- Both `paths` and `files` support globs/wildcards
+- `files` can both be directories or regular files
+- You can provide as many `paths` and `files` as you like
+- If no `conditions` are provided then the task is always enabled
+- Allows for general rules/tasks that are auto enabled/disabled for eg. repos, git projects and so on.
+
+## Enabling and disabling
+
+Conditions can be enabled/disabled from the cli with the following option:
+
+```bash
+Options:
+  -c, --conditions <CONDITIONS>
+          enable conditions
+
+          [possible values: true, false]
+```
+
+Conditions are default enabled and will always be disabled for validation (see below why).
+
+## Validation
+
+The [validator](08-validation.md) will never mark a task as failed even if conditions are not met. The status will always be `passed`.
+But it's still useful for debugging your conditions when running the validator in verbose mode (for example, with `aliasx -v validate` or `aliasx --verbose validate`), as it will explicitly state if a task was skipped or not, for example:
+
+```bash
+Should not be shown! PASS
+  ⏭ Conditions are not met (skipped)
+Git status PASS
+  ✓ Conditions are met
+```
+
+Conditions will only be marked as failed if the provided options can not be treated as a glob.
+
+---
+
+Navigation: ← [Previous: Validation](08-validation.md) | [Next: Installation & Getting Started](01-installation.md) →


### PR DESCRIPTION
Another new feature: enable tasks based on conditions.

These conditions can either be matching a filename in the current dir
and/or matching a a/several paths.

Both file and paths support globs.

Signed-off-by: Hans Binderup <hbinderup94@gmail.com>