### PR TITLE
cargo: remove bundled sq crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,6 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/aliasx-core/Cargo.toml
+++ b/aliasx-core/Cargo.toml
@@ -12,7 +12,7 @@ globset = "0.4.18"
 indexmap = { version="2.12.1", features = ["serde"] }
 owo-colors = { version = "4.2.3", features = ["supports-colors"] }
 regex = "1.12.2"
-rusqlite = { version = "0.39.0", features = ["bundled", "chrono"] }
+rusqlite = { version = "0.39.0", features = ["chrono"] }
 serde = { version="1.0.228", features = ["derive"] }
 serde_json5 = "0.2.1"
 serde_yaml = "0.9.34"


### PR DESCRIPTION
We should use the system's instead..