### PR TITLE
cli: rework globals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "serde_json",
  "serde_json5",
  "serde_yaml",
+ "strum",
 ]
 
 [[package]]

--- a/aliasx-cli/src/cli.rs
+++ b/aliasx-cli/src/cli.rs
@@ -1,6 +1,6 @@
 use std::{ops::Index, path::PathBuf, str::FromStr};
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use indexmap::IndexMap;
 
 use aliasx_core::{
@@ -13,38 +13,55 @@ use aliasx_core::{
 };
 use aliasx_tui::{fuzzy_finder, task_fuzzy_finder, FuzzyConfig, TuiSession};
 
+#[derive(Args)]
+struct TaskOptions {
+    /// the index of alias to handle
+    #[arg(short, long)]
+    index: Option<usize>,
+
+    /// verbose output
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// filter which tasks to include
+    #[arg(value_enum, short, long, default_value_t = TaskFilterCli::All)]
+    filter: TaskFilterCli,
+
+    /// only apply to native aliases
+    #[arg(short, long)]
+    native: bool,
+
+    /// enable conditions
+    #[arg(short, long)]
+    conditions: Option<bool>,
+}
+
 #[derive(Parser)]
 #[command(version, about = "Alias e(x)tended CLI")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
-
-    /// the index of alias to handle
-    #[arg(short, long, global = true)]
-    index: Option<usize>,
-
-    /// verbose output
-    #[arg(short, long, global = true)]
-    verbose: bool,
-
-    /// filter which tasks to include
-    #[arg(short, long, global = true, value_parser = TaskFilter::from_str, default_value_t = TaskFilter::All)]
-    filter: TaskFilter,
-
-    /// only apply to native aliases
-    #[arg(short, long, global = true)]
-    native: bool,
-
-    /// enable conditions
-    #[arg(short, long, global = true)]
-    conditions: Option<bool>,
 }
 
 #[derive(Subcommand)]
 enum Commands {
+    /// run a task by id
+    #[command(aliases = ["r"])]
+    Run {
+        #[command(flatten)]
+        task_options: TaskOptions,
+
+        /// alias id
+        #[arg()]
+        id: Option<String>,
+    },
+
     /// list all aliases (list)
     #[command(aliases = ["list"])]
-    Ls,
+    Ls {
+        #[command(flatten)]
+        task_options: TaskOptions,
+    },
 
     /// use fuzzy finder (f)
     #[command(aliases = ["f"])]
@@ -52,11 +69,17 @@ enum Commands {
         /// add query to search
         #[arg(short, long)]
         query: Option<String>,
+
+        #[command(flatten)]
+        task_options: TaskOptions,
     },
 
     /// run validation on configs files
     #[command()]
-    Validate,
+    Validate {
+        #[command(flatten)]
+        task_options: TaskOptions,
+    },
 
     /// use history instead of tasks
     #[command(aliases = ["h"])]
@@ -64,14 +87,9 @@ enum Commands {
         /// clear entire history
         #[arg(long)]
         clear: bool,
-    },
 
-    /// run a task by id
-    #[command(aliases = ["r"])]
-    Run {
-        /// alias id
-        #[arg()]
-        id: String,
+        #[command(flatten)]
+        task_options: TaskOptions,
     },
 
     /// create or convert existing configs
@@ -101,54 +119,62 @@ enum ConfigGeneratorSubCommands {
     },
 }
 
-fn get_tasks(cli: &Cli) -> anyhow::Result<TaskCollection> {
-    let enable_conditions = cli.conditions.unwrap_or(true);
-
-    let tasks = if cli.native {
+fn get_tasks(task_options: &TaskOptions) -> anyhow::Result<TaskCollection> {
+    let enable_conditions = task_options.conditions.unwrap_or(true);
+    let tasks = if task_options.native {
         aliases::get_aliases_as_tasks()?
     } else {
-        tasks::get_all_tasks(cli.filter, enable_conditions)?
+        tasks::get_all_tasks(task_options.filter, enable_conditions)?
     };
 
     Ok(tasks)
 }
 
-pub fn run() -> anyhow::Result<()> {
+pub fn parse_and_run() -> anyhow::Result<()> {
     let cli = Cli::parse();
+    run(&cli)
+}
 
+fn run(cli: &Cli) -> anyhow::Result<()> {
     match &cli.command {
-        Some(Commands::Ls {}) => {
-            let tasks = get_tasks(&cli)?;
-            if let Some(idx) = cli.index {
-                tasks.list_at(idx, cli.verbose)?;
+        Some(Commands::Ls { task_options }) => {
+            let tasks = get_tasks(&task_options)?;
+            if let Some(idx) = task_options.index {
+                tasks.list_at(idx, task_options.verbose)?;
             } else {
-                tasks.list_all(cli.verbose)?;
+                tasks.list_all(task_options.verbose)?;
             }
         }
 
-        Some(Commands::Fzf { query }) => {
-            let tasks = get_tasks(&cli)?;
-            run_fzf_task(&tasks, query.as_deref().unwrap_or(""), cli.verbose)?;
+        Some(Commands::Fzf {
+            task_options,
+            query,
+        }) => {
+            let tasks = get_tasks(&task_options)?;
+            run_fzf_task(&tasks, query.as_deref().unwrap_or(""), task_options.verbose)?;
         }
 
-        Some(Commands::Validate {}) => {
-            let tasks = tasks::get_all_tasks(cli.filter, false)?; // always disable conditions
-            if let Some(idx) = cli.index {
-                tasks.validate_at(idx, cli.verbose)?;
+        Some(Commands::Validate { task_options }) => {
+            let tasks = tasks::get_all_tasks(task_options.filter, false)?; // always disable conditions
+            if let Some(idx) = task_options.index {
+                tasks.validate_at(idx, task_options.verbose)?;
             } else {
-                tasks.validate_all(cli.verbose);
+                tasks.validate_all(task_options.verbose);
             }
         }
 
-        Some(Commands::History { clear }) => {
+        Some(Commands::History {
+            clear,
+            task_options,
+        }) => {
             if *clear {
                 History::clear()?;
                 return Ok(());
             }
 
-            let history = History::load_filtered(cli.filter)?;
+            let history = History::load_filtered(task_options.filter)?;
 
-            let idx = if let Some(idx) = cli.index {
+            let idx = if let Some(idx) = task_options.index {
                 idx
             } else {
                 let mut session = TuiSession::new()?;
@@ -174,7 +200,7 @@ pub fn run() -> anyhow::Result<()> {
             }
 
             let selected = history.index(idx);
-            let name = if cli.verbose {
+            let name = if task_options.verbose {
                 &selected.task_command
             } else {
                 &selected.task_name
@@ -182,41 +208,39 @@ pub fn run() -> anyhow::Result<()> {
             TaskCollection::run_command(name, &selected.task_command)?
         }
 
-        Some(Commands::Run { id }) => {
-            if cli.index.is_some() {
-                return Err(anyhow::anyhow!("cannot combine --index with run <id>"));
-            }
+        Some(Commands::Run { id, task_options }) => {
+            let tasks = get_tasks(&task_options)?;
+            let itask = match (task_options.index, &id) {
+                (Some(idx), None) => tasks.find_itask_from_idx(idx)?,
+                (None, Some(id)) => tasks.find_itask_from_id(id)?,
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "provide either an [ID] or --index, but not both"
+                    ))
+                }
+            };
 
-            let tasks = get_tasks(&cli)?;
-            let itask = tasks.find_itask_from_id(id)?;
             let mut session = TuiSession::new()?;
             let input_selections = run_fzf_inputs(&tasks, itask.idx, &mut session)?;
             drop(session);
 
-            tasks.execute(&itask, &input_selections, cli.verbose)?;
+            tasks.execute(&itask, &input_selections, task_options.verbose)?;
         }
 
-        Some(Commands::ConfigGenerator { command}) => match command {
+        Some(Commands::ConfigGenerator { command }) => match command {
             ConfigGeneratorSubCommands::PrintExample => ConfigGenerator::print_example_config()?,
-            ConfigGeneratorSubCommands::JsonToYaml { path } => ConfigGenerator::convert_json_to_yaml(PathBuf::from(path))?,
-            ConfigGeneratorSubCommands::YamlToJson { path } => ConfigGenerator::convert_yaml_to_json(PathBuf::from(path))?,
+            ConfigGeneratorSubCommands::JsonToYaml { path } => {
+                ConfigGenerator::convert_json_to_yaml(PathBuf::from(path))?
+            }
+            ConfigGeneratorSubCommands::YamlToJson { path } => {
+                ConfigGenerator::convert_yaml_to_json(PathBuf::from(path))?
+            }
         },
 
         None => {
-            let tasks = get_tasks(&cli)?;
-            if cli.index.is_none() {
-                run_fzf_task(&tasks, "", cli.verbose)?;
-                return Ok(());
-            }
-
-            if let Some(idx) = cli.index {
-                let itask = tasks.find_itask_from_idx(idx)?;
-                let mut session = TuiSession::new()?;
-                let input_selections = run_fzf_inputs(&tasks, itask.idx, &mut session)?;
-                drop(session);
-
-                tasks.execute(&itask, &input_selections, cli.verbose)?;
-            }
+            let tasks = tasks::get_all_tasks(TaskFilter::All, true)?;
+            run_fzf_task(&tasks, "", false)?;
+            return Ok(());
         }
     }
 
@@ -272,22 +296,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_id_only() {
-        let args = ["aliasx", "-i", "7"];
-        let cli = Cli::try_parse_from(&args).unwrap();
+    fn test_no_subcommand() {
+        let args = ["aliasx", "-i", "7", "-v"];
+        let cli = Cli::try_parse_from(&args);
 
-        assert!(cli.command.is_none());
-        assert_eq!(cli.index, Some(7));
+        assert!(cli.is_err());
     }
 
     #[test]
     fn test_list_id() {
-        let args = ["aliasx", "--index", "2", "ls"];
+        let args = ["aliasx", "ls", "--index", "2"];
         let cli = Cli::try_parse_from(&args).unwrap();
 
-        assert!(matches!(cli.command, Some(Commands::Ls { .. })));
-        assert_eq!(cli.index, Some(2));
-        assert_eq!(cli.native, false);
+        match cli.command {
+            Some(Commands::Ls { task_options }) => {
+                assert_eq!(task_options.index.unwrap(), 2)
+            }
+            _ => panic!("wrong subcommand"),
+        }
     }
 
     #[test]
@@ -295,8 +321,13 @@ mod tests {
         let args = ["aliasx", "ls"];
         let cli = Cli::try_parse_from(&args).unwrap();
 
-        assert!(matches!(cli.command, Some(Commands::Ls { .. })));
-        assert_eq!(cli.native, false);
+        match cli.command {
+            Some(Commands::Ls { task_options }) => {
+                assert!(task_options.index.is_none());
+                assert!(!task_options.native);
+            }
+            _ => panic!("wrong subcommand"),
+        }
     }
 
     #[test]
@@ -305,31 +336,93 @@ mod tests {
         let cli = Cli::try_parse_from(&args).unwrap();
 
         match cli.command {
-            Some(Commands::Fzf { query, .. }) => assert_eq!(query, Some("hello".into())),
-            _ => panic!("Expected fzf command with query"),
+            Some(Commands::Fzf {
+                query,
+                task_options,
+            }) => {
+                assert_eq!(query.unwrap(), "hello");
+                assert!(!task_options.native);
+            }
+            _ => panic!("wrong subcommand"),
         }
-
-        assert_eq!(cli.native, false);
     }
 
     #[test]
     fn test_fzf_with_native_aliases() {
-        let args = ["aliasx", "-n", "f", "--query", "native"];
+        let args = ["aliasx", "fzf", "-n", "--query", "native"];
         let cli = Cli::try_parse_from(&args).unwrap();
 
         match cli.command {
-            Some(Commands::Fzf { query, .. }) => assert_eq!(query, Some("native".into())),
-            _ => panic!("Expected fzf command with query"),
+            Some(Commands::Fzf {
+                query,
+                task_options,
+            }) => {
+                assert_eq!(query.unwrap(), "native");
+                assert_eq!(task_options.native, true);
+            }
+            _ => panic!("wrong subcommand"),
         }
-
-        assert_eq!(cli.native, true);
     }
 
     #[test]
-    fn test_verbose_flag() {
-        let args = ["aliasx", "-v"];
+    fn test_run_command_with_id() {
+        let args = ["aliasx", "run", "build"];
         let cli = Cli::try_parse_from(&args).unwrap();
 
-        assert!(cli.verbose, "Expected verbose flag to be true");
+        match cli.command {
+            Some(Commands::Run { id, task_options }) => {
+                assert_eq!(id.unwrap(), "build");
+                assert!(task_options.index.is_none());
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_run_command_with_idx() {
+        let args = ["aliasx", "run", "--index", "1"];
+        let cli = Cli::try_parse_from(&args).unwrap();
+
+        match cli.command {
+            Some(Commands::Run { id, task_options }) => {
+                assert!(id.is_none());
+                assert_eq!(task_options.index.unwrap(), 1);
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+
+    #[test]
+    fn test_run_command_with_no_id_nor_idx() {
+        let args = ["aliasx", "run"];
+        let cli = Cli::try_parse_from(&args).unwrap();
+
+        match &cli.command {
+            Some(Commands::Run { id, task_options }) => {
+                assert!(id.is_none());
+                assert!(task_options.index.is_none());
+            }
+            _ => panic!("wrong subcommand"),
+        }
+
+        let res = run(&cli);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_run_command_with_both_id_nor_idx() {
+        let args = ["aliasx", "run", "task", "--index", "0"];
+        let cli = Cli::try_parse_from(&args).unwrap();
+
+        match &cli.command {
+            Some(Commands::Run { id, task_options }) => {
+                assert_eq!(id.as_ref().unwrap(), "task");
+                assert_eq!(task_options.index.unwrap(), 0);
+            }
+            _ => panic!("wrong subcommand"),
+        }
+
+        let res = run(&cli);
+        assert!(res.is_err());
     }
 }

--- a/aliasx-cli/src/cli.rs
+++ b/aliasx-cli/src/cli.rs
@@ -1,8 +1,3 @@
-use std::{ops::Index, path::PathBuf, str::FromStr};
-
-use clap::{Args, Parser, Subcommand};
-use indexmap::IndexMap;
-
 use aliasx_core::{
     aliases,
     config_generator::ConfigGenerator,
@@ -12,6 +7,26 @@ use aliasx_core::{
     tasks::{self},
 };
 use aliasx_tui::{fuzzy_finder, task_fuzzy_finder, FuzzyConfig, TuiSession};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use indexmap::IndexMap;
+use std::{ops::Index, path::PathBuf};
+
+#[derive(ValueEnum, Clone, Debug, Copy)]
+enum TaskFilterCli {
+    All,
+    Local,
+    Global,
+}
+
+impl From<TaskFilterCli> for TaskFilter {
+    fn from(f: TaskFilterCli) -> Self {
+        match f {
+            TaskFilterCli::All => TaskFilter::All,
+            TaskFilterCli::Local => TaskFilter::Local,
+            TaskFilterCli::Global => TaskFilter::Global,
+        }
+    }
+}
 
 #[derive(Args)]
 struct TaskOptions {
@@ -45,13 +60,13 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// run a task by id
+    /// run a task
     #[command(aliases = ["r"])]
     Run {
         #[command(flatten)]
         task_options: TaskOptions,
 
-        /// alias id
+        /// id of task to run
         #[arg()]
         id: Option<String>,
     },
@@ -124,7 +139,7 @@ fn get_tasks(task_options: &TaskOptions) -> anyhow::Result<TaskCollection> {
     let tasks = if task_options.native {
         aliases::get_aliases_as_tasks()?
     } else {
-        tasks::get_all_tasks(task_options.filter, enable_conditions)?
+        tasks::get_all_tasks(task_options.filter.into(), enable_conditions)?
     };
 
     Ok(tasks)
@@ -155,7 +170,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
         }
 
         Some(Commands::Validate { task_options }) => {
-            let tasks = tasks::get_all_tasks(task_options.filter, false)?; // always disable conditions
+            let tasks = tasks::get_all_tasks(task_options.filter.into(), false)?; // always disable conditions
             if let Some(idx) = task_options.index {
                 tasks.validate_at(idx, task_options.verbose)?;
             } else {
@@ -172,7 +187,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
                 return Ok(());
             }
 
-            let history = History::load_filtered(task_options.filter)?;
+            let history = History::load_filtered(task_options.filter.into())?;
 
             let idx = if let Some(idx) = task_options.index {
                 idx

--- a/aliasx-cli/src/lib.rs
+++ b/aliasx-cli/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod cli;
 
-pub fn run() -> anyhow::Result<()> {
-    cli::run()
+pub fn parse_and_run() -> anyhow::Result<()> {
+    cli::parse_and_run()
 }

--- a/aliasx-cli/src/main.rs
+++ b/aliasx-cli/src/main.rs
@@ -1,7 +1,7 @@
 use aliasx_cli::cli;
 
 fn main() {
-    cli::run().unwrap_or_else(|err| {
+    cli::parse_and_run().unwrap_or_else(|err| {
         eprintln!("aliasx: {}", err);
         std::process::exit(1);
     });

--- a/aliasx-core/Cargo.toml
+++ b/aliasx-core/Cargo.toml
@@ -17,3 +17,4 @@ serde = { version="1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 serde_json5 = "0.2.1"
 serde_yaml = "0.9.34"
+strum = { version="0.27.2", features = ["derive"] }

--- a/aliasx-core/src/history.rs
+++ b/aliasx-core/src/history.rs
@@ -35,8 +35,7 @@ impl HistoryEntry {
 impl FromSql for TaskFilter {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         let s = value.as_str()?;
-
-        s.parse().map_err(|e: String| FromSqlError::Other(e.into()))
+        s.parse::<Self>().map_err(|e| FromSqlError::Other(e.into()))
     }
 }
 

--- a/aliasx-core/src/task_filter.rs
+++ b/aliasx-core/src/task_filter.rs
@@ -1,9 +1,8 @@
-use std::str::FromStr;
-use std::fmt;
-
+use strum::{Display, EnumString};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(EnumString, Display, Deserialize, Serialize, Debug, PartialEq, Clone, Copy)]
+#[strum(serialize_all = "lowercase")]
 pub enum TaskFilter {
     All,
     Local,
@@ -23,29 +22,6 @@ impl TaskFilter {
 
     pub fn include_global(self) -> bool {
         matches!(self, TaskFilter::All | TaskFilter::Global)
-    }
-}
-
-impl FromStr for TaskFilter {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "all" => Ok(TaskFilter::All),
-            "local" => Ok(TaskFilter::Local),
-            "global" => Ok(TaskFilter::Global),
-            _ => Err(format!("Invalid value for TaskFilter: {}", s)),
-        }
-    }
-}
-
-impl fmt::Display for TaskFilter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            TaskFilter::All => "all",
-            TaskFilter::Local => "local",
-            TaskFilter::Global => "global",
-        };
-        write!(f, "{}", s)
     }
 }
 

--- a/docs/features/06-cli.md
+++ b/docs/features/06-cli.md
@@ -6,25 +6,20 @@ You can always run `aliasx --help` for full self documentation.
 $ aliasx --help
 Alias e(x)tended CLI
 
-Usage: aliasx [OPTIONS] [COMMAND]
+Usage: aliasx [COMMAND]
 
 Commands:
-  ls        list all aliases (list)
-  fzf       use fuzzy finder (f)
-  validate  run validation on configs files
-  history   use history instead of tasks
-  run       run a task by id
-  help      Print this message or the help of the given subcommand(s)
+  run               run a task
+  ls                list all aliases (list)
+  fzf               use fuzzy finder (f)
+  validate          run validation on configs files
+  history           use history instead of tasks
+  config-generator  create or convert existing configs
+  help              Print this message or the help of the given subcommand(s)
 
 Options:
-  -i, --index <INDEX>            the index of alias to handle
-  -v, --verbose                  verbose output
-  -f, --filter <FILTER>          filter which tasks to include [default: all]
-  -n, --native                   only apply to native aliases
-  -c, --conditions <CONDITIONS>  enable conditions [possible values: true, false]
-  -h, --help                     Print help
-  -V, --version                  Print version
-
+  -h, --help     Print help
+  -V, --version  Print version
 ```
 
 Quick start
@@ -32,8 +27,29 @@ Quick start
 - Run `aliasx` to open the interactive fuzzy finder and pick a task or alias.
 - Use `aliasx ls` to print a list of available tasks and aliases.
 - Run `aliasx validate` to validate your current config.
-- Run `aliasx --index N` to query only that index into the command.
 - Run `aliasx run <task-id>` to run a task based on assigned id
+- Run `aliasx run --index N` to run a task based on assigned index
+
+Each command has a dedicated helper page. Call it with `--help` or `help`:
+
+```bash
+$ aliasx run --help
+run a task
+
+Usage: aliasx run [OPTIONS] [ID]
+
+Arguments:
+  [ID]  id of task to run
+
+Options:
+  -i, --index <INDEX>
+  -v, --verbose
+  -f, --filter <FILTER>          [default: all] [possible values: all, local, global]
+  -n, --native
+  -c, --conditions <CONDITIONS>  [possible values: true, false]
+  -h, --help                     Print help
+
+```
 
 ### Common flags
 
@@ -49,8 +65,8 @@ Quick start
 
 - Interactive search: aliasx
 - Search with query: aliasx f --query "test"
-- Show local tasks only: aliasx -f local ls
-- Run item by index: aliasx --index 3
+- Show local tasks only: aliasx ls -f local
+- Run item by index: aliasx run --index 3
 
 ---
 


### PR DESCRIPTION
I'm tired of the globals. They're polluting and making it less flexible
to add new commands -> all new commands seem to support all options.

Now it's explicit and I like that better.

Also help is much more useful now.

Signed-off-by: Hans Binderup <hbinderup94@gmail.com>