### PR TITLE
task_options: add support for cwd and envs

### DIFF
--- a/.aliasx.yaml
+++ b/.aliasx.yaml
@@ -40,6 +40,12 @@ tasks:
       paths:
         - "**/repos/**"
         - "/home/user/github/**"
+  - label: "Task with options (env and cwd)"
+    command: "echo \"task with env: $ALIASX_ENV from $(pwd)\""
+    options:
+      env:
+        ALIASX_ENV: "THIS_IS_A_TEST"
+      cwd: "/var/log"
 
 inputs:
   - id: some-int

--- a/aliasx-cli/src/cli.rs
+++ b/aliasx-cli/src/cli.rs
@@ -1,5 +1,12 @@
 use aliasx_core::{
-    aliases, config_generator::ConfigGenerator, history::History, task_collection::TaskCollection, task_filter::TaskFilter, task_reader::TaskFormat, tasks::{self}
+    aliases,
+    config_generator::ConfigGenerator,
+    history::History,
+    task_collection::TaskCollection,
+    task_filter::TaskFilter,
+    task_options::TaskOption,
+    task_reader::TaskFormat,
+    tasks::{self, TaskEntry},
 };
 use aliasx_tui::{fuzzy_finder, task_fuzzy_finder, FuzzyConfig, TuiSession};
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -228,12 +235,20 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
             }
 
             let selected = history.index(idx);
-            let name = if task_options.verbose {
-                &selected.task_command
-            } else {
-                &selected.task_name
+
+            // reconstruct the task from history
+            let task = TaskEntry {
+                label: selected.task_name.clone(),
+                command: selected.task_command.clone(),
+                options: Some(TaskOption {
+                    cwd: selected.cwd.clone(),
+                    env: selected.env.clone(),
+                }),
+                id: None,
+                conditions: None,
             };
-            TaskCollection::run_command(name, &selected.task_command)?
+
+            TaskCollection::run_command(&task, &selected.task_command, task_options.verbose)?
         }
 
         Some(Commands::Run { id, task_options }) => {
@@ -258,7 +273,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
         Some(Commands::ConfigGenerator { command }) => match command {
             ConfigGeneratorSubCommands::ExampleConfig { format } => {
                 ConfigGenerator::print_example_config((*format).into())?
-            },
+            }
             ConfigGeneratorSubCommands::JsonToYaml { path } => {
                 ConfigGenerator::convert_json_to_yaml(PathBuf::from(path))?
             }

--- a/aliasx-core/src/aliases.rs
+++ b/aliasx-core/src/aliases.rs
@@ -17,6 +17,7 @@ fn parse_aliases(output: &str) -> Result<Tasks> {
                     command: cmd.trim_matches('\'').to_string(),
                     id: Option::None,
                     conditions: Option::None,
+                    options: Option::None,
                 };
                 tasks.tasks.insert(task);
             }

--- a/aliasx-core/src/config_generator.rs
+++ b/aliasx-core/src/config_generator.rs
@@ -20,6 +20,7 @@ impl ConfigGenerator {
             label: "Simple task".to_string(),
             command: "echo 'This is just a simple task'".to_string(),
             conditions: None,
+            options: None,
         });
 
         tasks.tasks.insert(TaskEntry {
@@ -27,6 +28,7 @@ impl ConfigGenerator {
             label: "Perform build".to_string(),
             command: "echo 'building ${input:build-type} in ${mapping:build-dir}...'".to_string(),
             conditions: None,
+            options: None,
         });
 
         tasks.inputs.push(Input {

--- a/aliasx-core/src/history.rs
+++ b/aliasx-core/src/history.rs
@@ -1,13 +1,12 @@
+use anyhow::{anyhow, Context};
+use chrono::{DateTime, Local, Utc};
+use indexmap::IndexMap;
+use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ValueRef};
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use chrono::{DateTime, Local, Utc};
-use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ValueRef};
-use serde::{Deserialize, Serialize};
-
-use anyhow::{anyhow, Context};
-use rusqlite::{params, Connection};
-
-use crate::task_filter::TaskFilter;
+use crate::{task_filter::TaskFilter, tasks::TaskEntry};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HistoryEntry {
@@ -17,17 +16,21 @@ pub struct HistoryEntry {
     pub started_at: DateTime<Utc>,
     pub exit_code: i32,
     pub scope: TaskFilter,
+    pub cwd: Option<PathBuf>,
+    pub env: IndexMap<String, String>,
 }
 
 impl HistoryEntry {
-    pub fn new(task_name: &str, task_command: &str, exit_code: i32, scope: TaskFilter) -> Self {
+    pub fn new(task: &TaskEntry, task_command: &str, exit_code: i32, scope: TaskFilter) -> Self {
         Self {
             id: 0,
-            task_name: task_name.to_string(),
+            task_name: task.label.clone(),
             task_command: task_command.to_string(),
             started_at: Utc::now(),
             exit_code,
-            scope: scope,
+            scope,
+            cwd: task.get_option_cwd().map(|p| p.to_path_buf()),
+            env: task.get_option_env().cloned().unwrap_or_default(),
         }
     }
 }
@@ -59,7 +62,9 @@ impl History {
                 task_command TEXT    NOT NULL,
                 started_at   TEXT    NOT NULL,
                 exit_code    INTEGER NOT NULL,
-                scope        TEXT    NOT NULL
+                scope        TEXT    NOT NULL,
+                cwd          TEXT,
+                env          TEXT    NOT NULL DEFAULT '{}'
             );
         ",
         )?;
@@ -92,12 +97,23 @@ impl History {
     pub fn load() -> anyhow::Result<Vec<HistoryEntry>> {
         let conn = Self::connect()?;
         let mut stmt = conn.prepare(
-            "SELECT id, task_name, task_command, started_at, exit_code, scope
+            "SELECT id, task_name, task_command, started_at, exit_code, scope, cwd, env
          FROM task_history
          ORDER BY started_at DESC LIMIT 100",
         )?;
+
         let rows = stmt
             .query_map([], |row| {
+                let cwd: Option<String> = row.get(6)?;
+                let env_json: String = row.get(7)?;
+                let env: IndexMap<String, String> =
+                    serde_json::from_str(&env_json).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            7,
+                            rusqlite::types::Type::Text,
+                            Box::new(e),
+                        )
+                    })?;
                 Ok(HistoryEntry {
                     id: row.get(0)?,
                     task_name: row.get(1)?,
@@ -105,6 +121,8 @@ impl History {
                     started_at: row.get(3)?,
                     exit_code: row.get(4)?,
                     scope: row.get(5)?,
+                    cwd: cwd.map(PathBuf::from),
+                    env,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -122,15 +140,20 @@ impl History {
     pub fn append(entry: &HistoryEntry) -> anyhow::Result<()> {
         let mut conn = Self::connect()?;
         let tx = conn.transaction()?;
+        let env_json = serde_json::to_string(&entry.env)?;
         tx.execute(
-            "INSERT INTO task_history (task_name, task_command, started_at, exit_code, scope)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+        "INSERT INTO task_history (task_name, task_command, started_at, exit_code, scope, cwd, env)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             params![
                 &entry.task_name,
                 &entry.task_command,
                 &entry.started_at,
                 &entry.exit_code,
                 entry.scope.to_string(),
+                entry.cwd
+                     .as_deref()
+                     .map(|p| p.to_string_lossy().into_owned()),
+                env_json,
             ],
         )?;
 

--- a/aliasx-core/src/lib.rs
+++ b/aliasx-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod input_mapping;
 pub mod task_collection;
 pub mod task_conditions;
 pub mod task_filter;
+pub mod task_options;
 pub mod task_reader;
 pub mod tasks;
 pub mod validator;

--- a/aliasx-core/src/task_collection.rs
+++ b/aliasx-core/src/task_collection.rs
@@ -1,16 +1,14 @@
-use anyhow::{anyhow, Context};
-use execute::shell;
-use indexmap::{IndexMap, IndexSet};
-use std::process::Stdio;
-
 use crate::history::HistoryEntry;
-
 use crate::{
     history::History,
     input::Input,
     tasks::{TaskEntry, Tasks},
     validator::Validator,
 };
+use anyhow::{anyhow, Context};
+use execute::shell;
+use indexmap::{IndexMap, IndexSet};
+use std::process::Stdio;
 
 #[derive(Debug, Default)]
 pub struct TaskCollection {
@@ -182,10 +180,10 @@ impl TaskCollection {
             .source
             .apply_mappings(&task_command, input_selections)?;
 
-        let res = Self::run_command(&itask.task.format(verbose), &task_command);
+        let res = Self::run_command(&itask.task, &task_command, verbose);
 
         let entry = HistoryEntry::new(
-            &itask.task.label,
+            &itask.task,
             &task_command,
             if res.is_ok() { 0 } else { 1 },
             itask.source.scope,
@@ -200,10 +198,18 @@ impl TaskCollection {
         res
     }
 
-    pub fn run_command(label: &str, task_command: &str) -> anyhow::Result<()> {
-        println!("aliasx | {}\n", label);
+    pub fn run_command(task: &TaskEntry, task_command: &str, verbose: bool) -> anyhow::Result<()> {
+        println!("aliasx | {}\n", task.format(verbose));
 
         let mut cmd = shell(&task_command);
+        if let Some(cwd) = task.get_option_cwd() {
+            cmd.current_dir(cwd);
+        }
+
+        if let Some(env) = task.get_option_env() {
+            cmd.envs(env);
+        }
+
         cmd.stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
@@ -235,6 +241,7 @@ mod tests {
             command: command.to_string(),
             id: id,
             conditions: Option::None,
+            options: Option::None,
         }
     }
 

--- a/aliasx-core/src/task_options.rs
+++ b/aliasx-core/src/task_options.rs
@@ -1,0 +1,30 @@
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use std::{hash::Hash, path::PathBuf};
+
+// TODO: add to docs
+// TODO: consider adding example to config generator
+// TODO: add validation?
+
+// Follows the structure of "vs-code tasks options"
+
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct TaskOption {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<PathBuf>,
+
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub env: IndexMap<String, String>,
+}
+
+impl Hash for TaskOption {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.cwd.hash(state);
+
+        // IndexMap is deterministic hence why this is okay
+        for (k, v) in &self.env {
+            k.hash(state);
+            v.hash(state);
+        }
+    }
+}

--- a/aliasx-core/src/tasks.rs
+++ b/aliasx-core/src/tasks.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use anyhow::{anyhow, Context};
 use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
@@ -7,6 +9,7 @@ use crate::input_mapping::InputMapping;
 use crate::task_collection::TaskCollection;
 use crate::task_conditions::TaskCondition;
 use crate::task_filter::TaskFilter;
+use crate::task_options::TaskOption;
 use crate::task_reader;
 
 #[derive(Hash, Eq, PartialEq, Debug, Serialize, Deserialize)]
@@ -19,6 +22,9 @@ pub struct TaskEntry {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conditions: Option<TaskCondition>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<TaskOption>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -47,6 +53,14 @@ impl TaskEntry {
 
     pub fn print(&self, idx: usize, verbose: bool, width: usize) {
         println!("[{:0>width$}] {}", idx, self.format(verbose));
+    }
+
+    pub fn get_option_cwd(&self) -> Option<&Path> {
+        self.options.as_ref()?.cwd.as_deref()
+    }
+
+    pub fn get_option_env(&self) -> Option<&IndexMap<String, String>> {
+        Some(&self.options.as_ref()?.env)
     }
 }
 
@@ -186,6 +200,7 @@ mod tests {
             command: command.to_string(),
             id: Some("id".to_string()),
             conditions: Option::None,
+            options: Option::None,
         }
     }
 


### PR DESCRIPTION
Now it's possible to inject envionment variables and working dirs into the tasks.

The syntax follows the "options" attributes in vs-code (to stay compatible).

The syntax is documented in the example config.

TODO: add to docs
TODO: consider adding example to config generator
TODO: add validation?

NOTE: this breaks history meaning that a `aliasx history --clear` is required for that to continue working. As aliasx is still in "beta" I'm allowing this breaking change to happen.